### PR TITLE
Run number documentation (ldmx-sw/iss1045)

### DIFF
--- a/docs/Configuring-the-Simulation.md
+++ b/docs/Configuring-the-Simulation.md
@@ -26,6 +26,15 @@ Parameter | Type | Accessed By | Description
 `enableHitContribs` | bool | RootPersistencyManager | Should the simulation allow for the different contributors to an ECal hit be stored?
 `compressHitContribs` | bool | RootPersistencyManager | Should the simulation compress the contributors by combining any contributors with the same PDG ID?
 
+Note: In earlier versions of LDMX-sw, you would set the `runNumber` parameter in
+the simulator. The `runNumber` is a unique number (int) that identifies this
+run. In current versions of LDMX-sw, the `runNumber` is set as a parameter to
+the process directly. In other words, along the lines of
+```python
+p = ldmxcfg.Process("simulation")
+p.runNumber = 9001
+```
+
 ### Biasing
 
 Biasing is helpful for efficiently simulating the detector's response to various events.

--- a/docs/Configuring-the-Simulation.md
+++ b/docs/Configuring-the-Simulation.md
@@ -18,7 +18,6 @@ Parameter | Type | Accessed By | Description
 --- | --- | --- | ---
 `detector` | string | Simulator | Full path to detector gdml description
 `description` | string | Simulator and RootPersistencyManager | Concise phrase describing this simulation in a human-readable way
-`runNumber` | int | Simulator and RootPersistencyManager | Unique number identifying this run
 `verbosity` | int | Simulator | Integer flag describing how verbose to be
 `scoringPlanes` | string | RunManager | Full path to scoring plane gdml description
 `randomSeeds` | vector of ints | Simulator | Lists random seeds to pass to Geant4

--- a/docs/Configuring-the-Simulation.md
+++ b/docs/Configuring-the-Simulation.md
@@ -28,17 +28,18 @@ Parameter | Type | Accessed By | Description
 
 Note: In earlier versions of LDMX-sw, you would set the `runNumber` parameter in
 the simulator. The `runNumber` is a unique number (int) that identifies this
-run. In current versions of LDMX-sw, the `runNumber` is set as a parameter to
+run. In current versions of LDMX-sw, the `runNumber` is called `run` and is set as a parameter to
 the process directly. In other words, along the lines of
 ```python
 p = ldmxcfg.Process("simulation")
-p.runNumber = 9001
+p.run = 9001
 ```
 
 ### Biasing
 
-Biasing is helpful for efficiently simulating the detector's response to various events.
-The biasing parameters are given directly to the simulation and are listed below.
+Biasing is helpful for efficiently simulating the detector's response to various
+events. The biasing parameters are given directly to the simulation and are
+listed below.
 
 Parameter | Type | Accessed By | Description
 --- | --- | --- | ---

--- a/docs/Generating-Simulation-Samples.md
+++ b/docs/Generating-Simulation-Samples.md
@@ -80,7 +80,7 @@ from LDMX.Framework import ldmxcfg
 p = ldmxcfg.Process( "sim" )
 
 # Set the unique number that identifies this run
-p.runNumber = 9001 
+p.run = 9001 
 # import a template simulator and change some of its parameters
 from LDMX.SimCore import generators
 from LDMX.SimCore import simulator

--- a/docs/Generating-Simulation-Samples.md
+++ b/docs/Generating-Simulation-Samples.md
@@ -79,6 +79,8 @@ from LDMX.Framework import ldmxcfg
 # Create the necessary process object (call this pass "sim")
 p = ldmxcfg.Process( "sim" )
 
+# Set the unique number that identifies this run
+p.runNumber = 9001 
 # import a template simulator and change some of its parameters
 from LDMX.SimCore import generators
 from LDMX.SimCore import simulator
@@ -86,7 +88,6 @@ from LDMX.SimCore import simulator
 mySim = simulator.simulator( "mySim" )
 mySim.setDetector( 'ldmx-det-v12' )
 mySim.generators = [ generators.single_4gev_e_upstream_tagger() ]
-mySim.runNumber = 9001
 mySim.description = 'I am a basic working example!'
 
 # import chip/geometry conditions

--- a/docs/Running-and-configuring-fire.md
+++ b/docs/Running-and-configuring-fire.md
@@ -32,7 +32,7 @@ It is encouraged to browse the python modules themselves for all the details, bu
 - `passName` (string)
    - **required** Given in the constructor, tag for the process as a whole.
    - For example: `"10MeVSignal"` for a simulation of a 10MeV A'
-- `runNumber` (integer)
+- `run` (integer)
   - Unique number identifying the run 
   - For example: `9001`
   - Default is `0`

--- a/docs/Running-and-configuring-fire.md
+++ b/docs/Running-and-configuring-fire.md
@@ -32,6 +32,10 @@ It is encouraged to browse the python modules themselves for all the details, bu
 - `passName` (string)
    - **required** Given in the constructor, tag for the process as a whole.
    - For example: `"10MeVSignal"` for a simulation of a 10MeV A'
+- `runNumber` (integer)
+  - Unique number identifying the run 
+  - For example: `9001`
+  - Default is `0`
 - `maxEvents` (integer)
    - Maximum number of events to run for
    - Required for Production Mode (no input files)


### PR DESCRIPTION
This PR updates the documentation regarding setting the runNumber with the simulator vs the process object. See https://github.com/LDMX-Software/ldmx-sw/issues/1045 for details. I'm noticing now that I gave this branch the wrong name... oh well 

I've removed references to `sim.runNumber` and left a note about it where I thought it might be relevant. I've also added `process.run` where both the process and simulator were used 

There are still places where we use `sim.runNumber` but its only in the doxygen/sphinx stuff which I'm assuming is auotgenerated from the C++/python sources 