### PR TITLE
Move building to be the first

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,9 +1,6 @@
 [Welcome](index.md)
 
 # Getting Started
-- [Analyzing ldmx-sw Event Files](analysis/intro.md)
-  - [Using Python (Efficiently)](analysis/python.md)
-  - [Using ldmx-sw Directly](analysis/ldmx-sw.md)
 - [Building and Installing ldmx-sw](building/intro.md)
   - [Shared Computing Clusters](building/clusters.md)
   - [Updating ldmx-sw](building/updating.md)
@@ -18,6 +15,9 @@
   - [Event Skimming](config/event-skimming.md)
   - [Tips and Tricks](config/config-tips.md)
 - [Exercises](Startup-Exercises.md)
+- [Analyzing ldmx-sw Event Files](analysis/intro.md)
+  - [Using Python (Efficiently)](analysis/python.md)
+  - [Using ldmx-sw Directly](analysis/ldmx-sw.md)
 
 # User Guides
 - [Transition to ldmx-sw v4](transition-to-ldmx-sw-v4.md)


### PR DESCRIPTION
Right now the analyzing the ldmx trees it the first thing in the summary. I find it more natural to start with the fact that first we have to have ldmx-sw cloned and compiled. This PR just moves the analysis to the end, and by that has the building part first